### PR TITLE
Add group to daemon project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -459,6 +459,8 @@ configure(project(':statsnode')) {
 configure(project(':daemon')) {
     mainClassName = 'bisq.daemon.app.BisqDaemonMain'
 
+    group = "network.bisq"
+
     dependencies {
         compile project(':core')
         implementation("io.grpc:grpc-stub:$grpcVersion") {


### PR DESCRIPTION
Adding the `group` declaration is required to include the daemon as a dependency in `bisq-android` project.